### PR TITLE
Make WidgetInteraction a dependency.

### DIFF
--- a/FicsItNetworks.uplugin
+++ b/FicsItNetworks.uplugin
@@ -27,6 +27,12 @@
             "Name": "SML",
             "SemVersion": "^3.1.0",
             "Enabled": true
+        }, 
+        {
+            "Name": "PTSDInteraction",
+            "SemVersion": "^1.0.0",
+            "bIsOptional": false,
+            "Enabled": true
         }
     ]
 }

--- a/Source/FicsItNetworks/Computer/FINComputerSubsystem.cpp
+++ b/Source/FicsItNetworks/Computer/FINComputerSubsystem.cpp
@@ -4,12 +4,6 @@
 #include "FGCharacterPlayer.h"
 
 AFINComputerSubsystem::AFINComputerSubsystem() {
-	Input = CreateDefaultSubobject<UInputComponent>("Input");
-	Input->BindAction("PrimaryFire", EInputEvent::IE_Pressed, this, &AFINComputerSubsystem::OnPrimaryFirePressed).bConsumeInput = false;
-	Input->BindAction("PrimaryFire", EInputEvent::IE_Released, this, &AFINComputerSubsystem::OnPrimaryFireReleased).bConsumeInput = false;
-	Input->BindAction("SecondaryFire", EInputEvent::IE_Pressed, this, &AFINComputerSubsystem::OnSecondaryFirePressed).bConsumeInput = false;
-	Input->BindAction("SecondaryFire", EInputEvent::IE_Released, this, &AFINComputerSubsystem::OnSecondaryFireReleased).bConsumeInput = false;
-
 	SetActorTickEnabled(true);
 	PrimaryActorTick.SetTickFunctionEnable(true);
 	PrimaryActorTick.bCanEverTick = true;
@@ -17,23 +11,6 @@ AFINComputerSubsystem::AFINComputerSubsystem() {
 
 	SetReplicates(true);
 	bAlwaysRelevant = true;
-}
-
-void AFINComputerSubsystem::OnConstruction(const FTransform& Transform) {
-	Super::OnConstruction(Transform);
-}
-
-void AFINComputerSubsystem::BeginPlay() {
-	Super::BeginPlay();
-
-	TArray<AActor*> FoundCharacters;
-	UGameplayStatics::GetAllActorsOfClass(this, AFGCharacterPlayer::StaticClass(), FoundCharacters);
-	for (AActor* Character : FoundCharacters) AttachWidgetInteractionToPlayer(Cast<AFGCharacterPlayer>(Character));
-}
-
-void AFINComputerSubsystem::Tick(float dt) {
-	Super::Tick(dt);
-	this->GetWorld()->GetFirstPlayerController()->PushInputComponent(Input);
 }
 
 bool AFINComputerSubsystem::ShouldSave_Implementation() const {
@@ -44,50 +21,6 @@ void AFINComputerSubsystem::PreSaveGame_Implementation(int32 saveVersion, int32 
 	Version = FINLatestVersion;
 }
 
-void AFINComputerSubsystem::OnPrimaryFirePressed() {
-	AController* controller = GetWorld()->GetFirstPlayerController();
-	if (controller) {
-		AFGCharacterPlayer* character = Cast<AFGCharacterPlayer>(controller->GetCharacter());
-		if (character) {
-			UWidgetInteractionComponent** Comp = ScreenInteraction.Find(character);
-			if (Comp && IsValid(*Comp)) (*Comp)->PressPointerKey(EKeys::LeftMouseButton);
-		}
-	}
-}
-
-void AFINComputerSubsystem::OnPrimaryFireReleased() {
-	AController* controller = GetWorld()->GetFirstPlayerController();
-	if (controller) {
-		AFGCharacterPlayer* character = Cast<AFGCharacterPlayer>(controller->GetCharacter());
-		if (character) {
-			UWidgetInteractionComponent** Comp = ScreenInteraction.Find(character);
-			if (Comp && IsValid(*Comp)) (*Comp)->ReleasePointerKey(EKeys::LeftMouseButton);
-		}
-	}
-}
-
-void AFINComputerSubsystem::OnSecondaryFirePressed() {
-	AController* controller = GetWorld()->GetFirstPlayerController();
-	if (controller) {
-		AFGCharacterPlayer* character = Cast<AFGCharacterPlayer>(controller->GetCharacter());
-		if (character) {
-			UWidgetInteractionComponent** Comp = ScreenInteraction.Find(character);
-			if (Comp && IsValid(*Comp)) (*Comp)->PressPointerKey(EKeys::RightMouseButton);
-		}
-	}
-}
-
-void AFINComputerSubsystem::OnSecondaryFireReleased() {
-	AController* controller = GetWorld()->GetFirstPlayerController();
-	if (controller) {
-		AFGCharacterPlayer* character = Cast<AFGCharacterPlayer>(controller->GetCharacter());
-		if (character) {
-			UWidgetInteractionComponent** Comp = ScreenInteraction.Find(character);
-			if (Comp && IsValid(*Comp)) (*Comp)->ReleasePointerKey(EKeys::RightMouseButton);
-		}
-	}
-}
-
 AFINComputerSubsystem* AFINComputerSubsystem::GetComputerSubsystem(UObject* WorldContext) {
 #if WITH_EDITOR
 	return nullptr;
@@ -96,26 +29,4 @@ AFINComputerSubsystem* AFINComputerSubsystem::GetComputerSubsystem(UObject* Worl
 	USubsystemActorManager* SubsystemActorManager = WorldObject->GetSubsystem<USubsystemActorManager>();
 	check(SubsystemActorManager);
 	return SubsystemActorManager->GetSubsystemActor<AFINComputerSubsystem>();
-}
-
-void AFINComputerSubsystem::AttachWidgetInteractionToPlayer(AFGCharacterPlayer* character) {
-	if (!IsValid(character) || !character->GetController() || !character->GetController()->IsLocalPlayerController()) return;
-	DetachWidgetInteractionToPlayer(character);
-	UWidgetInteractionComponent* Comp = NewObject<UWidgetInteractionComponent>(character);
-	Comp->InteractionSource = EWidgetInteractionSource::World;
-	UCameraComponent* cam = Cast<UCameraComponent>(character->GetComponentByClass(UCameraComponent::StaticClass()));
-	Comp->InteractionDistance = 10000.0;
-	Comp->VirtualUserIndex = VirtualUserNum++;
-	Comp->RegisterComponent();
-	Comp->AttachToComponent(cam, FAttachmentTransformRules::KeepRelativeTransform);
-	ScreenInteraction.Add(character, Comp);
-}
-
-void AFINComputerSubsystem::DetachWidgetInteractionToPlayer(AFGCharacterPlayer* character) {
-	if (!IsValid(character)) return;
-	UWidgetInteractionComponent** Comp = ScreenInteraction.Find(character);
-	if (Comp) {
-		(*Comp)->UnregisterComponent();
-		ScreenInteraction.Remove(character);
-	}
 }

--- a/Source/FicsItNetworks/Computer/FINComputerSubsystem.h
+++ b/Source/FicsItNetworks/Computer/FINComputerSubsystem.h
@@ -17,8 +17,6 @@ public:
 	UPROPERTY(SaveGame, BlueprintReadOnly)
 	TEnumAsByte<EFINCustomVersion> Version = EFINCustomVersion::FINBeforeCustomVersionWasAdded;
 
-	int VirtualUserNum = 0;
-
 	AFINComputerSubsystem();
 	
 	// Begin IFGSaveInterface

--- a/Source/FicsItNetworks/Computer/FINComputerSubsystem.h
+++ b/Source/FicsItNetworks/Computer/FINComputerSubsystem.h
@@ -14,41 +14,18 @@ class FICSITNETWORKS_API AFINComputerSubsystem : public AModSubsystem, public IF
 	GENERATED_BODY()
 	
 public:
-	UPROPERTY()
-	TMap<AFGCharacterPlayer*, UWidgetInteractionComponent*> ScreenInteraction;
-
-	UPROPERTY()
-	UInputComponent* Input;
-
 	UPROPERTY(SaveGame, BlueprintReadOnly)
 	TEnumAsByte<EFINCustomVersion> Version = EFINCustomVersion::FINBeforeCustomVersionWasAdded;
 
 	int VirtualUserNum = 0;
 
 	AFINComputerSubsystem();
-
-	// Begin AActor
-	virtual void OnConstruction(const FTransform& Transform) override;
-	virtual void BeginPlay() override;
-	virtual void Tick(float dt) override;
-	// End AActor
 	
 	// Begin IFGSaveInterface
 	virtual bool ShouldSave_Implementation() const override;
 	virtual void PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion) override;
 	// End IFGSaveInterface
 
-	void OnPrimaryFirePressed();
-	void OnPrimaryFireReleased();
-	void OnSecondaryFirePressed();
-	void OnSecondaryFireReleased();
-
 	UFUNCTION(BlueprintCallable, Category = "Computer", meta = (WorldContext = "WorldContext"))
 	static AFINComputerSubsystem* GetComputerSubsystem(UObject* WorldContext);
-
-	UFUNCTION(BlueprintCallable, Category = "Computer")
-	void AttachWidgetInteractionToPlayer(AFGCharacterPlayer* character);
-	
-	UFUNCTION(BlueprintCallable, Category = "Computer")
-	void DetachWidgetInteractionToPlayer(AFGCharacterPlayer* character);
 };

--- a/Source/FicsItNetworks/FicsItNetworksModule.cpp
+++ b/Source/FicsItNetworks/FicsItNetworksModule.cpp
@@ -139,22 +139,6 @@ void FFicsItNetworksModule::StartupModule(){
 		SUBSCRIBE_METHOD_VIRTUAL(IFGDismantleInterface::Dismantle_Implementation, (void*)static_cast<const IFGDismantleInterface*>(GetDefault<AFGBuildable>()), &AFGBuildable_Dismantle_Implementation)
 		SUBSCRIBE_METHOD_VIRTUAL(IFGDismantleInterface::GetDismantleRefund_Implementation, (void*)static_cast<const IFGDismantleInterface*>(GetDefault<AFGBuildable>()), &AFGBuildable_GetDismantleRefund_Implementation)
 		
-		SUBSCRIBE_METHOD_VIRTUAL_AFTER(AFGCharacterPlayer::BeginPlay, (void*)GetDefault<AFGCharacterPlayer>(), [](AActor* self) {
-			AFGCharacterPlayer* character = Cast<AFGCharacterPlayer>(self);
-			if (character) {
-				AFINComputerSubsystem* SubSys = AFINComputerSubsystem::GetComputerSubsystem(self->GetWorld());
-				if (SubSys) SubSys->AttachWidgetInteractionToPlayer(character);
-			}
-		})
-
-		SUBSCRIBE_METHOD_VIRTUAL_AFTER(AFGCharacterPlayer::EndPlay, (void*)GetDefault<AFGCharacterPlayer>(), [](AActor* self, EEndPlayReason::Type Reason) {
-			AFGCharacterPlayer* character = Cast<AFGCharacterPlayer>(self);
-			if (character) {
-				AFINComputerSubsystem* SubSys = AFINComputerSubsystem::GetComputerSubsystem(self->GetWorld());
-				if (SubSys) SubSys->DetachWidgetInteractionToPlayer(character);
-			}
-		})
-
 		SUBSCRIBE_METHOD_VIRTUAL_AFTER(AFGGameMode::PostLogin, (void*)GetDefault<AFGGameMode>(), [](AFGGameMode* gm, APlayerController* pc) {
 			if (gm->HasAuthority() && !gm->IsMainMenuGameMode()) {
 				gm->RegisterRemoteCallObjectClass(UFINComputerRCO::StaticClass());


### PR DESCRIPTION
Hi,

I have a couple of WIP mods that require adding a WidgetInteraction component to the player character. As your (Awesome!) mod does the same thing, it seems sensible to pull that small bit of functionality out to a seperate SML dependency.

I'll hold off publishing "PTSDInteraction" to SML until/unless you say it's ok, as it's basically a ctrl-c ctrl-v of your implementation.

[PTSDInteraction Source](https://github.com/ptsd/PTSDInteraction)

This PR:
- Remove all WidgetInteraction related stuff.
- Add PTSDInteraction as a dependency.

I've also added the ability to register widgets as desiring KB focus on primarybutton press, with a caveat listed in the PTSDInteraction readme.

I'm unable to properly test FIN with this change as the %ASSETS% patch doesn't seem to be public and ALPAKIT won't complete without some BP changes.

I have tested by adding PTSDInteraction as a dependency to a fresh mod, and all interaction stuff works as expected.

On a side note, your amazing mod is a brilliant reference for anyone learning Satisfactory C++ modding, huge respect for making the source public 👍 