### PR TITLE
Updated function to new function name  from 'childs' to 'children'

### DIFF
--- a/docs/modules/ROOT/pages/lua/examples/drive.adoc
+++ b/docs/modules/ROOT/pages/lua/examples/drive.adoc
@@ -19,7 +19,7 @@ if fs.initFileSystem("/dev") == false then
     computer.panic("Cannot initialize /dev")
 end
 -- List all the drives
-for _, drive in pairs(fs.childs("/dev")) do
+for _, drive in pairs(fs.children("/dev")) do
     print(drive)
 end
 ----


### PR DESCRIPTION
Not sure if it was a typo or the API changed, but after debugging by dumping the filesystem initFileSystem object it had no key named childs, only children. Tested in game
<img width="1014" height="1101" alt="FicsIt-Networks_debug_lua_3" src="https://github.com/user-attachments/assets/5253d72e-0277-4ba4-aa19-40b2672cac79" />
<img width="799" height="904" alt="FicsIt-Networks_debug_lua_2" src="https://github.com/user-attachments/assets/07d88ab3-2e02-407d-bb03-9711494d5c69" />
<img width="879" height="848" alt="FicsIt-Networks_debug_lua_1" src="https://github.com/user-attachments/assets/74e2f969-3294-4eb2-8ac3-a8a82576688e" />
