### PR TITLE
Replaced calls to inline methods with virtual method calls

### DIFF
--- a/Source/FicsItReflection/Private/FIRTraceSteps.cpp
+++ b/Source/FicsItReflection/Private/FIRTraceSteps.cpp
@@ -160,7 +160,7 @@ Step(AFGBuildableRailroadTrack, UFGRailroadTrackConnectionComponent, {
 	return A->GetTrackGraphID() == B->GetTrack()->GetTrackGraphID();
 })
 Step(UFGRailroadTrackConnectionComponent, AFGBuildableRailroadTrack, {
-    return  B->GetConnection(0) && A->GetTrack()->GetTrackGraphID() == B->GetConnection(0)->GetTrack()->GetTrackGraphID();
+    return A->GetTrack() != nullptr && A->GetTrack()->GetTrackGraphID() == B->GetTrackGraphID();
 })
 
 Step(UFGRailroadTrackConnectionComponent, UFGRailroadTrackConnectionComponent, {

--- a/Source/FicsItReflection/Private/Reflection/Source/Static/FIRSourceStatic_Railroad.cpp
+++ b/Source/FicsItReflection/Private/Reflection/Source/Static/FIRSourceStatic_Railroad.cpp
@@ -570,7 +570,8 @@ BeginFunc(getConnection, "Get Connection", "Returns the railroad track connectio
 	InVal(0, RInt, direction, "Direction", "The direction of which you want to get the connector from. 0 = front, 1 = back")
 	OutVal(1, RTrace<UFGRailroadTrackConnectionComponent>, connection, "Connection", "The connection component in the given direction.")
 	Body()
-	connection = Ctx.GetTrace() / self->GetConnection(FMath::Clamp<int>(direction, 0, 1));
+	UFGConnectionComponent* rawConn = direction == 0 ? self->GetSplineConnection0() : self->GetSplineConnection1();
+	connection = Ctx.GetTrace() / Cast<UFGRailroadTrackConnectionComponent>(rawConn);
 } EndFunc()
 BeginFunc(getTrackGraph, "Get Track Graph", "Returns the track graph of which this track is part of.") {
 	OutVal(0, RStruct<FFIRTrackGraph>, track, "Track", "The track graph of which this track is part of.")

--- a/Source/FicsItReflection/Private/Reflection/Source/Static/FIRSourceStatic_Railroad.cpp
+++ b/Source/FicsItReflection/Private/Reflection/Source/Static/FIRSourceStatic_Railroad.cpp
@@ -576,7 +576,8 @@ BeginFunc(getConnection, "Get Connection", "Returns the railroad track connectio
 BeginFunc(getTrackGraph, "Get Track Graph", "Returns the track graph of which this track is part of.") {
 	OutVal(0, RStruct<FFIRTrackGraph>, track, "Track", "The track graph of which this track is part of.")
     Body()
-    track = (FIRAny)FFIRTrackGraph{Ctx.GetTrace(), self->GetTrackGraphID()};
+    static FIntProperty* Prop = CastField<FIntProperty>(AFGBuildableRailroadTrack::StaticClass()->FindPropertyByName(TEXT("mTrackGraphID")));
+    track = (FIRAny)FFIRTrackGraph{Ctx.GetTrace(), Prop->GetPropertyValue_InContainer(self)};
 } EndFunc()
 BeginFunc(getVehicles, "Get Vehicles", "Returns a list of Railroad Vehicles on the Track") {
 	OutVal(0, RArray<RTrace<AFGRailroadVehicle>>, vehicles, "Vehicles", "THe list of vehicles on the track.")
@@ -588,7 +589,7 @@ BeginFunc(getVehicles, "Get Vehicles", "Returns a list of Railroad Vehicles on t
 	vehicles = Vehicles;
 } EndFunc()
 BeginProp(RFloat, length, "Length", "The length of the track.") {
-	FIRReturn self->GetLength();
+	FIRReturn self->GetSplineComponent()->GetSplineLength();
 } EndProp()
 BeginProp(RBool, isOwnedByPlatform, "Is Owned By Platform", "True if the track is part of/owned by a railroad platform.") {
 	FIRReturn self->GetIsOwnedByPlatform();


### PR DESCRIPTION
I ran into https://github.com/Panakotta00/FicsIt-Networks/issues/521 and decided to propose a fix.

This PR replaces some calls to `GetConnection` on `AFGBuildableRailRoadTrack` with calls to `GetSplineConnection0` and `GetSplineConnection1`. `GetConnection` is an inlined method, while `GetSplineConnection*` are virtual. The fields on `AFGBuildableRailroadTrack` seem to have changed in a recent update. Likely a field was removed, or a new field was added before `mConnections`. SatisfactoryModLoader doesn't reflect that yet.

The inline `GetConnection` method uses `mConnections` at the memory location implied by SatisfactoryModLoader, which is currently invalid, while `GetSplineConnection*` uses the correct memory location as it is defined in the Satisfactory DLLs itself. I tested with the repro from https://github.com/Panakotta00/FicsIt-Networks/issues/521 to make sure that `GetSplineConnection*` actually does the same as `GetConnection` and it does.

I removed another call to `GetConnection` entirely as it was used to call `GetTrackGraphId`, logically `X->GetTrackGraphId()` should always be the same as `X->GetConnection(0)->GetTrack()->GetTrackId()`.

The bug would probably have fixed itself when an updated SatisfactoryModLoader is released. By doing it this way, the function becomes a bit more resilient to future regressions. 